### PR TITLE
Fix rune tracking + small UI updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.24.1'
+def runeLiteVersion = '1.6.30'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -36,13 +36,11 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.events.AnimationChanged;
-import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.callback.ClientThread;
@@ -125,7 +123,9 @@ public class RunecraftingTrackerPlugin extends Plugin
 	{
 		if (event.getGameState() == GameState.LOGIN_SCREEN)
 		{
-			clientThread.invokeLater(this::init);
+			if (runeTracker.size() == 0) {
+				clientThread.invokeLater(this::init);
+			}
 		}
 	}
 

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -63,7 +63,6 @@ import net.runelite.client.util.ImageUtil;
 )
 public class RunecraftingTrackerPlugin extends Plugin
 {
-	private static final String CRAFTED_NOTIFICATION_MESSAGE = "You bind the temple's power into runes.";
 	private static final int RUNECRAFTING_ANIMATION_ID = 791;
 
 	private RunecraftingTrackerPanel uiPanel;

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -131,18 +131,6 @@ public class RunecraftingTrackerPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onChatMessage(ChatMessage event)
-	{
-		if (event.getType() == ChatMessageType.SPAM || event.getType() == ChatMessageType.GAMEMESSAGE)
-		{
-			if (event.getMessage().contains(CRAFTED_NOTIFICATION_MESSAGE))
-			{
-				takeInventorySnapshot();
-			}
-		}
-	}
-
-	@Subscribe
 	public void onAnimationChanged(AnimationChanged event)
 	{
 		if (client.getLocalPlayer() == null || client.getLocalPlayer().getName() == null)

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -90,7 +90,7 @@ public class RunecraftingTrackerPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "icon.png");
-		uiPanel = new RunecraftingTrackerPanel(runeTracker);
+		uiPanel = new RunecraftingTrackerPanel(manager, runeTracker);
 
 		uiNavigationButton = NavigationButton.builder()
 			.tooltip("Runecrafting Tracker")


### PR DESCRIPTION
Fixes #1 

So, I wanted to use this plugin but I saw it was not working. This PR fixes the plugin and cleans a bit of the UI. 

The plugin was broken because the inventory was only stored whenever the message ```You bind the temple's power into runes.``` was sent in chat. This does work for the Ourania altar, however, this message is not sent for other altars. I altered the code to respond to the runecrafting animation instead of the previously mentioned chat message.

I also made some small changes to the UI to make it a bit more clear and nice to look at (as well as adding the error panel):

### No runes crafted:
![Error Panel](https://user-images.githubusercontent.com/22432233/97731653-b57a9d00-1ad5-11eb-9084-53a10af117ba.png)

### Updated interface:
![Runecrafting Tracker Interface](https://user-images.githubusercontent.com/22432233/97731641-b4497000-1ad5-11eb-8636-f68a8388dc56.png)

### Old interface:
![Display panel](https://i.imgur.com/AXrX60D.png)


