### PR TITLE
Fixed race condition in "onGameStateChanged", and added support for tracking combination runes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.30'
+def runeLiteVersion = '1.9.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPanel.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPanel.java
@@ -29,9 +29,7 @@ import java.awt.Color;
 import java.awt.GridLayout;
 import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 
 import net.runelite.client.game.ItemManager;
@@ -79,7 +77,7 @@ public class RunecraftingTrackerPanel extends PluginPanel
 		pack();
 	}
 
-	protected void pack()
+		protected void pack()
 	{
 		layoutContainer.removeAll();
 
@@ -183,6 +181,36 @@ public class RunecraftingTrackerPanel extends PluginPanel
 		textContainer.add(middleLine);
 
 		panelContainer.add(textContainer, BorderLayout.CENTER);
+
+		final JMenuItem resetAll = new JMenuItem("Reset All");
+
+		resetAll.addActionListener(e ->
+		{
+			final int result = JOptionPane.showOptionDialog(panelContainer, String.format("<html>This will permanently delete <b>all</b> crafted runes.</html>"),
+					"Are you sure?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE,
+					null, new String[]{"Yes", "No"}, "No");
+
+			if (result != JOptionPane.YES_OPTION)
+			{
+				return;
+			}
+
+
+			for (PanelItemData item : runeTracker)
+			{
+				item.setCrafted(0);
+				item.setVisible(false);
+			}
+
+			layoutContainer.removeAll();
+			layoutContainer.add(errorPanel);
+
+		});
+
+		final JPopupMenu popupMenu = new JPopupMenu();
+		popupMenu.setBorder(new EmptyBorder(5, 5, 5, 5));
+		popupMenu.add(resetAll);
+		panelContainer.setComponentPopupMenu(popupMenu);
 
 		return panelContainer;
 	}

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -65,7 +65,7 @@ public class RunecraftingTrackerPlugin extends Plugin
 
 	private RunecraftingTrackerPanel uiPanel;
 
-	private int[] runeIDs = {556, 558, 555, 557, 554, 559, 564, 562, 9075, 561, 563, 560, 565, 566, 21880};
+	private int[] runeIDs = {556, 558, 555, 557, 554, 559, 564, 562, 9075, 561, 563, 560, 565, 566, 21880, 4695, 4696, 4698, 4697, 4694, 4699};
 
 	private NavigationButton uiNavigationButton;
 	private LinkedList<PanelItemData> runeTracker = new LinkedList<>();
@@ -121,7 +121,7 @@ public class RunecraftingTrackerPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOGIN_SCREEN)
+		if (event.getGameState() == GameState.LOGGING_IN)
 		{
 			if (runeTracker.size() == 0) {
 				clientThread.invokeLater(this::init);
@@ -228,5 +228,5 @@ public class RunecraftingTrackerPlugin extends Plugin
 	}
 
 	enum Runes
-	{AIR, MIND, WATER, EARTH, FIRE, BODY, COSMIC, CHAOS, ASTRAL, NATURE, LAW, DEATH, BLOOD, SOUL, WRATH}
+	{AIR, MIND, WATER, EARTH, FIRE, BODY, COSMIC, CHAOS, ASTRAL, NATURE, LAW, DEATH, BLOOD, SOUL, WRATH, MIST, DUST, MUD, SMOKE, STEAM, LAVA}
 }

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -147,6 +147,10 @@ public class RunecraftingTrackerPlugin extends Plugin
 			{
 				takeInventorySnapshot();
 			}
+			else
+			{
+				inventorySnapshot = null;
+			}
 		}
 	}
 
@@ -194,8 +198,7 @@ public class RunecraftingTrackerPlugin extends Plugin
 						}
 					}
 				}
-
-				inventorySnapshot = null;
+				inventorySnapshot = currentInventory;
 
 				try
 				{


### PR DESCRIPTION
**Fixed a race condition in "onGameStateChanged"**
If the OSRS Client finishes loading before the plugin, the "Gamestate.LOGIN_SCREEN" state may never trigger. Switching the check to "LOGGING_IN" ensurer the "runeTracker" linked list / panels are always initialised. (If they are not, the "processChange" code breaks on the for (PanelItemData item : panels) loop as there are no initialised panels).

**Added support for combination runes** 
Support for the various combination runes (Mist, Dust, Mud, Smoke, Steam, Lava) was added by adding their ID's to runeIDs Int[], and their names to the Runes Enum.