### PR TITLE
Refactor to use alternative event for tracking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.9.1'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPanel.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPanel.java
@@ -109,7 +109,8 @@ public class RunecraftingTrackerPanel extends PluginPanel
 
 	protected void refresh()
 	{
-		revalidate();
+		layoutContainer.revalidate();
+		layoutContainer.repaint();
 	}
 
 	protected LinkedList<PanelItemData> getRuneTracker()

--- a/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
+++ b/src/main/java/com/runecraftingtracker/RunecraftingTrackerPlugin.java
@@ -60,7 +60,6 @@ public class RunecraftingTrackerPlugin extends Plugin
     private RunecraftingTrackerPanel uiPanel;
 
     private final int[] runeIDs = {556, 558, 555, 557, 554, 559, 564, 562, 9075, 561, 563, 560, 565, 566, 21880, 4695, 4696, 4698, 4697, 4694, 4699};
-    private final int[] regionIds = new int[]{1111, 2222};
     private NavigationButton uiNavigationButton;
     private LinkedList<PanelItemData> runeTracker = new LinkedList<>();
     private Multiset<Integer> inventorySnapshot;


### PR DESCRIPTION
- Updated deprecated use of InventoryID and ItemStack to use new api
- When crafting in an area with multiple/players npcs the OnAnimation event was not always captured resulting in runes not being tracked. The plugin now uses the StatChanged event instead and checks that the changed stat is runecrafting.